### PR TITLE
Add option to retrieve old version of master

### DIFF
--- a/pcn_load_cpi.ado
+++ b/pcn_load_cpi.ado
@@ -23,6 +23,7 @@ clear                 ///
 version 14
 
 local outdir "p:/01.PovcalNet/01.Vintage_control/_aux/cpi"
+local time = clock("`c(current_time)'", "hms") // %tcHH:MM:SS
 if ("`version'" != "") {
   
   /*==================================================
@@ -59,8 +60,24 @@ if ("`version'" != "") {
   else {
     cap confirm number `version'
     if (_rc ==0) {
-      local vcnumber = `version'
-      local version: disp %tcDDmonCCYY_HH:MM:SS `vcnumber'
+		if (length("`version'")<18 & regexm("`version'", "-") | "`version'" == "0"){
+			loc i = subinstr("`version'", "-","",.)
+			loc i = `i'
+			loc versions : list sizeof local(vcnumbers)
+			mata: vermat = J(`versions',1,.)
+			loc j = 0
+			foreach vc of local vcnumbers {
+				loc ++j
+				mata: vermat[`j',1] = `vc' 
+			}
+			qui mata: sort(vermat,1)
+			loc i = `versions' - `i'
+			mata: st_numscalar("verScalar", vermat[`i',1])
+			loc version = verScalar
+		} 
+		local vcnumber = `version'
+		local version: disp %tcDDmonCCYY_HH:MM:SS `vcnumber'
+      
     }
     else {
       if (!regexm("`version'", "^[0-9]+[a-z]+[0-9]+ [0-9]+:[0-9]+:[0-9]+$") /* 

--- a/pcn_load_price.ado
+++ b/pcn_load_price.ado
@@ -59,8 +59,23 @@ if ("`version'" != "") {
   else {
     cap confirm number `version'
     if (_rc ==0) {
-      local vcnumber = `version'
-      local version: disp %tcDDmonCCYY_HH:MM:SS `vcnumber'
+      if (length("`version'")<18 & regexm("`version'", "-") | "`version'" == "0"){
+			loc i = subinstr("`version'", "-","",.)
+			loc i = `i'
+			loc versions : list sizeof local(vcnumbers)
+			mata: vermat = J(`versions',1,.)
+			loc j = 0
+			foreach vc of local vcnumbers {
+				loc ++j
+				mata: vermat[`j',1] = `vc' 
+			}
+			qui mata: sort(vermat,1)
+			loc i = `versions' - `i'
+			mata: st_numscalar("verScalar", vermat[`i',1])
+			loc version = verScalar
+		} 
+		local vcnumber = `version'
+		local version: disp %tcDDmonCCYY_HH:MM:SS `vcnumber'
     }
     else {
       if (!regexm("`version'", "^[0-9]+[a-z]+[0-9]+ [0-9]+:[0-9]+:[0-9]+$") /* 

--- a/pcn_master_load.ado
+++ b/pcn_master_load.ado
@@ -96,6 +96,21 @@ qui {
 	else {
 		cap confirm number `version'
 		if (_rc ==0) {
+		if (length("`version'")<18 & regexm("`version'", "-") | "`version'" == "0"){
+			loc i = subinstr("`version'", "-","",.)
+			loc i = `i'
+			loc versions : list sizeof local(vcnumbers)
+			mata: vermat = J(`versions',1,.)
+			loc j = 0
+			foreach vc of local vcnumbers {
+				loc ++j
+				mata: vermat[`j',1] = `vc' 
+			}
+			qui mata: sort(vermat,1)
+			loc i = `versions' - `i'
+			mata: st_numscalar("verScalar", vermat[`i',1])
+			loc version = verScalar
+			} 
 			local vcnumber  `version'
 		}
 		else {

--- a/pcn_primus_load.ado
+++ b/pcn_primus_load.ado
@@ -6,7 +6,7 @@ url:
 Dependencies:  The World Bank
 ----------------------------------------------------
 Creation Date:     7 Feb 2020 - 20:02:16
-Modification Date:
+Modification Date: 12 Jun 2020 - major change
 Do-file version:    01
 References:
 Output:
@@ -21,6 +21,8 @@ syntax [anything(name=subcmd id="subcommand")],  ///
 Status(string)			///
 load(string)				///
 VERsion(string) 			///
+MEeting(string)			///
+WYear(string)					///
 clear                   ///
 pause                   ///
 ]
@@ -48,16 +50,32 @@ else	 						 local maindir "p:\01.PovcalNet\03.QA\02.PRIMUS\pending"
 // Working directory
 //=======================================================
 
+if !inlist("`meeting'", "AM", "SM", "")	{
+	di "meeting must be SM or AM" 
+	error
+}
+
 * working month
 local cmonth: disp %tdnn date("`c(current_date)'", "DMY")
 *Working year
-local wkyr:  disp %tdCCyy date("`c(current_date)'", "DMY")
+if ("`wyear'" == ""){
+	local wkyr:  disp %tdCCyy date("`c(current_date)'", "DMY")
+}
+else{
+	local wkyr = `wyear'
+}
 * Either Annual meeting (AM) or Spring meeting (SM)
-if inrange(`cmonth', 1, 4) | inrange(`cmonth', 11, 12)  local meeting "SM"
-if inrange(`cmonth', 5, 10) local meeting "AM"
 
-if inrange(`cmonth', 11, 12) {
-	local wkyr = `wkyr' + 1  // workign for the next year's meeting
+if ("`meeting'" == ""){
+	if inrange(`cmonth', 1, 4) | inrange(`cmonth', 11, 12)  local meeting "SM"
+	if inrange(`cmonth', 5, 10) local meeting "AM"
+
+	if (inrange(`cmonth', 11, 12) & "`year'" == "") {
+		local wkyr = `wkyr' + 1  // workign for the next year's meeting
+	}
+}
+else{
+	local meeting = "`meeting'"
 }
 
 return local wkyr = `wkyr'


### PR DESCRIPTION
Add an option to pcn in which we can retrieve any version of the master file by using the syntax version(-#) in which # refers to the number of versions before the current version.

- Rewrites pcn primus load in compliance with the other function to load vintage files.  